### PR TITLE
fix: dockerfile alpine selected version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS builder
+FROM node:23.8-alpine3.20 AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN npm run build
 
 RUN npx prisma generate
 
-FROM node:alpine
+FROM node:23.8-alpine3.20
 
 WORKDIR /app
 


### PR DESCRIPTION
Moved from node:alpine to node:23.8-alpine3.20

Updating main so trio-signo-fullstack repo can work again