### PR TITLE
fix(auth): correct Google OAuth2 redirect URIs and dev frontend hostname

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -143,7 +143,7 @@ export class AuthController {
   }
 
   @Public()
-  @Get('google/callback')
+  @Get('google/redirect')
   @UseGuards(AuthGuard('google'))
   @ApiOperation({ summary: 'Google OAuth callback' })
   @ApiResponse({
@@ -170,7 +170,7 @@ export class AuthController {
       // Redirect to frontend with token
       const frontendUrl =
         this.configService.get<string>('FRONTEND_URL') ||
-        'http://localhost:3000';
+        'http://localhost:4000';
       this.logger.debug(`Redirecting to: ${frontendUrl}/signin?token=****`);
       res.redirect(`${frontendUrl}/signin?token=${token}`);
     } catch (error) {


### PR DESCRIPTION
- Renamed misused callback URLs to proper redirect naming for clarity and consistency
- Updated redirect URIs in env/config to match registered Google settings
- Fixed localhost:3000 references to localhost:4000 where applicable to reflect correct frontend dev URL